### PR TITLE
Improve backup config

### DIFF
--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -37,7 +37,7 @@
     name: 'tarsnapper'
     minute: '15'
     hour: '*/12'
-    job: 'PATH=$PATH:/usr/local/bin /usr/local/bin/tarsnapper -c /usr/local/etc/tarsnapper.yml make'
+    job: 'PATH=$PATH:/usr/local/bin /usr/local/bin/tarsnapper -c /usr/local/etc/tarsnapper.yml make --no-expire'
 
 - name: Copy backup config for home directory
   template:
@@ -51,8 +51,3 @@
     src: '901.tarsnap.sh.j2'
     dest: '/usr/local/etc/periodic/weekly/901.tarsnap'
     mode: 0755
-
-- name: Run tarsnap fsck
-  command: '/usr/local/bin/tarsnap --fsck'
-  changed_when: false
-  when: keyfile_created is changed

--- a/templates/periodic.conf.j2
+++ b/templates/periodic.conf.j2
@@ -9,15 +9,15 @@ hourly_show_badconfig="NO"
 
 hourly_zfs_snapshot_enable="YES"
 hourly_zfs_snapshot_pools="{{ host_srv_zpool_name }} {{ host_ioc_zpool_name }}"
-hourly_zfs_snapshot_keep=10
+hourly_zfs_snapshot_keep=12
 
 daily_zfs_snapshot_enable="YES"
 daily_zfs_snapshot_pools="{{ host_srv_zpool_name }} {{ host_ioc_zpool_name }}"
-daily_zfs_snapshot_keep=6
+daily_zfs_snapshot_keep=7
 
 weekly_zfs_snapshot_enable="YES"
 weekly_zfs_snapshot_pools="{{ host_srv_zpool_name }} {{ host_ioc_zpool_name }}"
-weekly_zfs_snapshot_keep=3
+weekly_zfs_snapshot_keep=4
 
 monthly_zfs_snapshot_enable="YES"
 monthly_zfs_snapshot_pools="{{ host_srv_zpool_name }} {{ host_ioc_zpool_name }}"

--- a/templates/tarsnapper.yml.j2
+++ b/templates/tarsnapper.yml.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 
 delta-names:
-  default: 3h 1d 7d 30d
+  default: 12h 7d 30d
 
 target: $name-$date
 


### PR DESCRIPTION
- only make tarsnap backups, do not expire (allows usage of write only
key)
- adjust tarsnapper intervals to only keep 2 backups per day
- extend zfs snapshots made via periodic.conf